### PR TITLE
Fix isKindOfClass, replace with isMemberOfClass where necessary

### DIFF
--- a/CrashLoggerLib/CrashLoggerUtilities.m
+++ b/CrashLoggerLib/CrashLoggerUtilities.m
@@ -59,11 +59,12 @@
 + (NSString*) ConvertToString: (id) object {
     if (object==nil) return nil;
     
+    // If the object is of type NSString or derives (!) from it, then return the object
     if ([object isKindOfClass:[NSString class]]) {
         return object;
     }
     
-    if ([object isKindOfClass:[NSException class]]){
+    if ([object isMemberOfClass:[NSException class]]){
         return [self NSExceptionToString:object];
     }
     

--- a/CrashLoggerLib/DebugLogger.m
+++ b/CrashLoggerLib/DebugLogger.m
@@ -18,8 +18,8 @@
 
 - (BOOL) handleObject:(id)object{
     
-    // If it's NSException (or derived type), then convert it to string and log as string
-    if ([object isKindOfClass:[NSException class]]){
+    // If it's NSException, then convert it to string and log as string
+    if ([object isMemberOfClass:[NSException class]]){
         return [self handle:[CrashLoggerUtilities NSExceptionToString:object]];
     } else {
     // Otherwise, try to convert the unknown type to string

--- a/CrashLoggerLib/ServerLogger.m
+++ b/CrashLoggerLib/ServerLogger.m
@@ -34,8 +34,8 @@
 }
 
 - (BOOL) handleObject:(id)object {
-    // If it's NSException (or derived type), then convert it to string and log as string
-    if ([object isKindOfClass:[NSException class]]){
+    // If it's NSException, then convert it to string and log as string
+    if ([object isMemberOfClass:[NSException class]]){
         return [self handle:[CrashLoggerUtilities NSExceptionToString:object]];
     }
     return false;


### PR DESCRIPTION
- Replaced isKindOfClass with isMemberOfClass where necessary, because
  isKindOfClass checks all class hieararchy while isMemberOfClass checks if object is exactly of the given type.
